### PR TITLE
Implement PersonaLens MVP according to specification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# PersonaLens MVP Configuration
+
+# LLM Provider - Choose ONE: "openai" or "anthropic"
+LLM_PROVIDER=anthropic
+
+# OpenAI Settings (if using OpenAI)
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o
+
+# Anthropic Settings (if using Anthropic)
+ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=claude-3-5-sonnet-20241022
+
+# Google Calendar OAuth
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=http://localhost:8000/oauth/callback

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+# Environment
+.env
+.venv/
+venv/
+env/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY app/ ./app/
+
+# Expose port
+EXPOSE 8000
+
+# Run the application
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+# PersonaLens MVP

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,35 @@
+from pydantic_settings import BaseSettings
+from typing import Literal
+
+
+class Settings(BaseSettings):
+    # LLM Configuration - Choose ONE: "openai" or "anthropic"
+    llm_provider: Literal["openai", "anthropic"] = "anthropic"
+
+    # OpenAI settings
+    openai_api_key: str = ""
+    openai_model: str = "gpt-4o"
+
+    # Anthropic settings
+    anthropic_api_key: str = ""
+    anthropic_model: str = "claude-3-5-sonnet-20241022"
+
+    # Google Calendar OAuth
+    google_client_id: str = ""
+    google_client_secret: str = ""
+    google_redirect_uri: str = "http://localhost:8000/oauth/callback"
+
+    # Confidence thresholds (from spec section 5.3)
+    calendar_confidence_threshold: float = 0.3
+    role_confidence_threshold: float = 0.4
+
+    # LLM constraints
+    micro_call_max_tokens: int = 300
+    primary_call_max_tokens: int = 2048
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+settings = Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+
+from app.routers import api
+
+
+app = FastAPI(
+    title="PersonaLens MVP",
+    description="Minimal, transparent, role-aware contextual lens for LLM responses",
+    version="1.0.0",
+)
+
+# Include API router
+app.include_router(api.router, tags=["PersonaLens"])
+
+
+@app.get("/health")
+async def health_check():
+    """Health check endpoint."""
+    return {"status": "healthy"}

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,154 @@
+from pydantic import BaseModel, Field
+from typing import Literal, Optional
+from enum import Enum
+
+
+# Enums for constrained values
+class TimeOfDay(str, Enum):
+    MORNING = "morning"
+    AFTERNOON = "afternoon"
+    EVENING = "evening"
+    NIGHT = "night"
+
+
+class Pressure(str, Enum):
+    LOW = "low"
+    MODERATE = "moderate"
+    HIGH = "high"
+
+
+class Interruptibility(str, Enum):
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class RoleSignal(str, Enum):
+    PROFESSIONAL = "professional"
+    PERSONAL = "personal"
+    MIXED = "mixed"
+
+
+class RoleType(str, Enum):
+    PROFESSIONAL = "professional"
+    PERSONAL = "personal"
+    CASUAL = "casual"
+
+
+class Tone(str, Enum):
+    PROFESSIONAL = "professional"
+    WARM = "warm"
+    CASUAL = "casual"
+
+
+class Verbosity(str, Enum):
+    CONCISE = "concise"
+    BALANCED = "balanced"
+
+
+class Hedging(str, Enum):
+    LOW = "low"
+    MODERATE = "moderate"
+    HIGH = "high"
+
+
+class Urgency(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+# Time Context (Section 4.1)
+class TimeContext(BaseModel):
+    current_iso: str
+    time_of_day: TimeOfDay
+    weekday: bool
+    business_hours: bool
+    urgency_bias: float = Field(ge=0.0, le=1.0)
+
+
+# Calendar Context (Section 4.2)
+class CalendarContextAvailable(BaseModel):
+    summary: str
+    pressure: Pressure
+    interruptibility: Interruptibility
+    role_signal: RoleSignal
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
+class CalendarContextUnavailable(BaseModel):
+    status: Literal["unavailable"] = "unavailable"
+
+
+# Role Guess (Section 4.3)
+class RoleProbabilities(BaseModel):
+    professional: float = Field(ge=0.0, le=1.0)
+    personal: float = Field(ge=0.0, le=1.0)
+    casual: float = Field(ge=0.0, le=1.0)
+
+
+class RoleGuess(BaseModel):
+    roles: RoleProbabilities
+    primary_role: RoleType
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
+# Lens Schema (Section 5.1)
+class ResponsePreferences(BaseModel):
+    tone: Tone
+    verbosity: Verbosity
+    hedging: Hedging
+
+
+class SituationalContext(BaseModel):
+    time_of_day: TimeOfDay
+    urgency: Urgency
+    interruptibility: Interruptibility
+
+
+class Lens(BaseModel):
+    active_role: RoleType
+    role_confidence: float = Field(ge=0.0, le=1.0)
+    response_preferences: ResponsePreferences
+    situational_context: SituationalContext
+    sources_used: list[str]
+
+
+# API Request/Response Models (Section 8)
+class QueryRequest(BaseModel):
+    query: str
+    preview_lens: bool = False
+    calendar_token: Optional[str] = None
+
+
+class QueryResponse(BaseModel):
+    response: str
+    lens: Lens
+    regenerated: bool
+    model: str
+    warning: Optional[str] = None
+
+
+class LensPreviewRequest(BaseModel):
+    query: str
+    calendar_token: Optional[str] = None
+
+
+class LensPreviewResponse(BaseModel):
+    lens: Lens
+    sources_used: list[str]
+
+
+# Internal models for calendar events
+class CalendarEvent(BaseModel):
+    start_time: str
+    end_time: str
+    category: str
+    attendee_count: int
+
+
+# Drift detection result
+class DriftResult(BaseModel):
+    drift_detected: bool
+    drift_type: Optional[Literal["over_certainty", "sycophancy", "ignored_context"]] = None
+    modifier: Optional[str] = None

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,0 +1,1 @@
+# PersonaLens Routers

--- a/app/routers/api.py
+++ b/app/routers/api.py
@@ -1,0 +1,176 @@
+from typing import Optional
+from fastapi import APIRouter, HTTPException
+
+from app.models import (
+    QueryRequest,
+    QueryResponse,
+    LensPreviewRequest,
+    LensPreviewResponse,
+    CalendarContextUnavailable,
+)
+from app.services.time_context import get_time_context
+from app.services.calendar_context import get_calendar_context
+from app.services.role_guess import get_role_guess
+from app.services.lens_assembly import assemble_lens, lens_to_yaml
+from app.services.drift_guard import detect_drift, get_regeneration_prompt_modifier
+from app.services.llm_client import llm_client
+
+
+router = APIRouter()
+
+
+# IMMUTABLE prompt template from spec section 6.2
+PRIMARY_SYSTEM_PROMPT = """You are a helpful assistant.
+The following YAML describes the user's current situation and role.
+Use it to adapt tone, depth, and framing.
+Do not mention the YAML explicitly.
+
+<user_context>
+{lens_yaml}
+</user_context>"""
+
+
+async def _gather_context(calendar_token: Optional[str]):
+    """
+    Gather all context following the runtime flow from spec section 2.1:
+    1. Time Context (local, sync)
+    2. Calendar Context (LLM micro-call)
+    3. Role Guess is handled separately as it needs the query
+    """
+    # Step 1: Time Context (local, deterministic)
+    time_context = get_time_context()
+
+    # Step 2: Calendar Context (LLM micro-call)
+    calendar_context = await get_calendar_context(calendar_token)
+
+    return time_context, calendar_context
+
+
+async def _generate_response(
+    query: str,
+    lens_yaml: str,
+    modifier: Optional[str] = None,
+) -> str:
+    """Generate response from primary LLM."""
+    system_prompt = PRIMARY_SYSTEM_PROMPT.format(lens_yaml=lens_yaml)
+
+    # Add modifier if provided (for regeneration)
+    if modifier:
+        system_prompt += f"\n\nAdditional instruction: {modifier}"
+
+    return await llm_client.primary_call(
+        system_prompt=system_prompt,
+        user_prompt=query,
+    )
+
+
+@router.post("/query", response_model=QueryResponse)
+async def query(request: QueryRequest):
+    """
+    Main query endpoint.
+
+    Runtime flow (spec section 2.1):
+    1. Time Context (local, sync)
+    2. Calendar Context (LLM micro-call)
+    3. Role Guess (LLM micro-call)
+    4. Lens Assembly (deterministic)
+    5. Primary LLM Call
+    6. Drift Guard (post-generation)
+    7. Final Response
+    """
+    try:
+        # Steps 1-2: Gather time and calendar context
+        time_context, calendar_context = await _gather_context(request.calendar_token)
+
+        # Step 3: Role Guess (LLM micro-call)
+        role_guess = await get_role_guess(
+            query=request.query,
+            time_context=time_context,
+            calendar_context=calendar_context,
+        )
+
+        # Step 4: Lens Assembly (deterministic)
+        lens = assemble_lens(
+            time_context=time_context,
+            calendar_context=calendar_context,
+            role_guess=role_guess,
+        )
+
+        lens_yaml = lens_to_yaml(lens)
+
+        # Step 5: Primary LLM Call
+        response = await _generate_response(request.query, lens_yaml)
+
+        # Step 6: Drift Guard (post-generation)
+        drift_result = detect_drift(response, lens)
+
+        regenerated = False
+        warning = None
+
+        if drift_result.drift_detected:
+            # Per spec section 7.2: Maximum 1 regeneration
+            modifier = get_regeneration_prompt_modifier(drift_result)
+            regenerated_response = await _generate_response(
+                request.query, lens_yaml, modifier
+            )
+
+            # Check second attempt
+            second_drift = detect_drift(regenerated_response, lens)
+
+            if second_drift.drift_detected:
+                # Per spec: If second attempt fails, return response with warning flag
+                response = regenerated_response
+                warning = f"Response may contain {second_drift.drift_type}"
+            else:
+                response = regenerated_response
+
+            regenerated = True
+
+        # Step 7: Final Response
+        return QueryResponse(
+            response=response,
+            lens=lens,
+            regenerated=regenerated,
+            model=llm_client.get_model_name(),
+            warning=warning,
+        )
+
+    except Exception as e:
+        # Per spec section 9: Primary LLM fails -> Return error to user
+        # Lens assembly fails -> Abort request
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/lens/preview", response_model=LensPreviewResponse)
+async def lens_preview(request: LensPreviewRequest):
+    """
+    Lens preview endpoint for transparency.
+
+    Shows what lens would be assembled for a given query
+    without making the primary LLM call.
+    """
+    try:
+        # Gather time and calendar context
+        time_context, calendar_context = await _gather_context(request.calendar_token)
+
+        # Get role guess
+        role_guess = await get_role_guess(
+            query=request.query,
+            time_context=time_context,
+            calendar_context=calendar_context,
+        )
+
+        # Assemble lens
+        lens = assemble_lens(
+            time_context=time_context,
+            calendar_context=calendar_context,
+            role_guess=role_guess,
+        )
+
+        return LensPreviewResponse(
+            lens=lens,
+            sources_used=lens.sources_used,
+        )
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,1 @@
+# PersonaLens Services

--- a/app/services/calendar_context.py
+++ b/app/services/calendar_context.py
@@ -1,0 +1,209 @@
+from datetime import datetime, timedelta
+from typing import Union
+import yaml
+
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+from app.models import (
+    CalendarContextAvailable,
+    CalendarContextUnavailable,
+    CalendarEvent,
+    Pressure,
+    Interruptibility,
+    RoleSignal,
+)
+from app.services.llm_client import llm_client
+
+
+# FIXED prompt from spec section 4.2 - DO NOT MODIFY
+CALENDAR_SYSTEM_PROMPT = """You summarize calendar pressure and availability.
+Return YAML only."""
+
+CALENDAR_USER_PROMPT_TEMPLATE = """Upcoming events:
+{event_list}
+
+Return:
+summary (1 sentence)
+pressure: low|moderate|high
+interruptibility: high|medium|low
+role_signal: professional|personal|mixed
+confidence: 0-1"""
+
+
+def _categorize_event(title: str) -> str:
+    """
+    Infer category from event title.
+    Strip title to just category - per spec preprocessing rules.
+    """
+    title_lower = title.lower()
+
+    # Professional indicators
+    professional_keywords = [
+        "meeting", "call", "sync", "standup", "review", "interview",
+        "presentation", "demo", "workshop", "training", "conference",
+        "client", "1:1", "1-1", "sprint", "planning", "retrospective"
+    ]
+
+    # Personal indicators
+    personal_keywords = [
+        "doctor", "dentist", "appointment", "lunch", "dinner",
+        "birthday", "anniversary", "gym", "workout", "pickup",
+        "dropoff", "school", "family", "personal"
+    ]
+
+    for keyword in professional_keywords:
+        if keyword in title_lower:
+            return "professional_meeting"
+
+    for keyword in personal_keywords:
+        if keyword in title_lower:
+            return "personal_event"
+
+    return "event"
+
+
+def _preprocess_events(events: list[dict]) -> list[CalendarEvent]:
+    """
+    Preprocess calendar events according to spec:
+    - Strip titles beyond category inference
+    - Replace names with counts
+    - Remove descriptions
+    """
+    processed = []
+
+    for event in events[:10]:  # Max 10 events per spec
+        start = event.get("start", {})
+        end = event.get("end", {})
+
+        # Get times
+        start_time = start.get("dateTime", start.get("date", ""))
+        end_time = end.get("dateTime", end.get("date", ""))
+
+        # Categorize and strip title
+        title = event.get("summary", "Untitled")
+        category = _categorize_event(title)
+
+        # Count attendees (replace names with count)
+        attendees = event.get("attendees", [])
+        attendee_count = len(attendees)
+
+        processed.append(CalendarEvent(
+            start_time=start_time,
+            end_time=end_time,
+            category=category,
+            attendee_count=attendee_count,
+        ))
+
+    return processed
+
+
+def _format_events_for_prompt(events: list[CalendarEvent]) -> str:
+    """Format preprocessed events for the LLM prompt."""
+    if not events:
+        return "No upcoming events"
+
+    lines = []
+    for event in events:
+        line = f"- {event.category} at {event.start_time}"
+        if event.attendee_count > 0:
+            line += f" ({event.attendee_count} attendees)"
+        lines.append(line)
+
+    return "\n".join(lines)
+
+
+def _parse_calendar_response(response: str) -> CalendarContextAvailable:
+    """Parse YAML response from LLM into CalendarContextAvailable."""
+    # Clean response - remove markdown code blocks if present
+    response = response.strip()
+    if response.startswith("```"):
+        lines = response.split("\n")
+        # Remove first and last lines (code block markers)
+        lines = [l for l in lines if not l.startswith("```")]
+        response = "\n".join(lines)
+
+    parsed = yaml.safe_load(response)
+
+    # Handle nested structure if present
+    if "calendar_context" in parsed:
+        parsed = parsed["calendar_context"]
+
+    return CalendarContextAvailable(
+        summary=parsed.get("summary", "Calendar context available"),
+        pressure=Pressure(parsed.get("pressure", "moderate")),
+        interruptibility=Interruptibility(parsed.get("interruptibility", "medium")),
+        role_signal=RoleSignal(parsed.get("role_signal", "mixed")),
+        confidence=float(parsed.get("confidence", 0.5)),
+    )
+
+
+async def fetch_calendar_events(credentials: Credentials) -> list[dict]:
+    """
+    Fetch calendar events from Google Calendar API.
+    Returns events from now to +24 hours.
+    """
+    service = build("calendar", "v3", credentials=credentials)
+
+    now = datetime.utcnow()
+    time_min = now.isoformat() + "Z"
+    time_max = (now + timedelta(hours=24)).isoformat() + "Z"
+
+    events_result = service.events().list(
+        calendarId="primary",
+        timeMin=time_min,
+        timeMax=time_max,
+        maxResults=10,
+        singleEvents=True,
+        orderBy="startTime",
+    ).execute()
+
+    return events_result.get("items", [])
+
+
+async def get_calendar_context(
+    access_token: str | None,
+) -> Union[CalendarContextAvailable, CalendarContextUnavailable]:
+    """
+    Get calendar context using LLM micro-call.
+
+    Args:
+        access_token: OAuth access token for Google Calendar
+
+    Returns:
+        CalendarContextAvailable if successful
+        CalendarContextUnavailable if calendar unavailable or error
+    """
+    if not access_token:
+        return CalendarContextUnavailable()
+
+    try:
+        # Build credentials from token
+        credentials = Credentials(token=access_token)
+
+        # Fetch events
+        events = await fetch_calendar_events(credentials)
+
+        if not events:
+            return CalendarContextUnavailable()
+
+        # Preprocess events
+        processed_events = _preprocess_events(events)
+
+        # Format for prompt
+        event_list = _format_events_for_prompt(processed_events)
+
+        # Make LLM micro-call with FIXED prompt
+        user_prompt = CALENDAR_USER_PROMPT_TEMPLATE.format(event_list=event_list)
+
+        response = await llm_client.micro_call(
+            system_prompt=CALENDAR_SYSTEM_PROMPT,
+            user_prompt=user_prompt,
+        )
+
+        return _parse_calendar_response(response)
+
+    except (HttpError, Exception):
+        # Per spec section 9: Calendar API down -> continue without calendar
+        return CalendarContextUnavailable()

--- a/app/services/drift_guard.py
+++ b/app/services/drift_guard.py
@@ -1,0 +1,120 @@
+import re
+from typing import Optional
+
+from app.models import Lens, DriftResult, Urgency
+
+
+# Detection rules from spec section 7.1
+
+# A. Over-Certainty regex
+OVER_CERTAINTY_PATTERN = re.compile(r"\b(definitely|always|never|100%)\b", re.IGNORECASE)
+
+# B. Sycophancy-Lite phrases
+SYCOPHANCY_PHRASES = [
+    "you're absolutely right",
+    "great point",
+    "couldn't agree more",
+]
+
+# C. Context keywords to check for high-pressure situations
+CONTEXT_KEYWORDS = [
+    "time",
+    "pressure",
+    "urgent",
+    "urgency",
+    "soon",
+    "quickly",
+    "brief",
+    "concise",
+    "busy",
+    "meeting",
+    "deadline",
+]
+
+
+def _check_over_certainty(response: str) -> bool:
+    """Check for over-certainty phrases."""
+    return bool(OVER_CERTAINTY_PATTERN.search(response))
+
+
+def _check_sycophancy(response: str) -> bool:
+    """Check for sycophancy-lite phrases."""
+    response_lower = response.lower()
+    return any(phrase in response_lower for phrase in SYCOPHANCY_PHRASES)
+
+
+def _check_context_ignorance(response: str, lens: Lens) -> bool:
+    """
+    Check if response ignores context when lens indicates high pressure.
+
+    Per spec: Response does not reference time pressure, role, or urgency
+    when lens indicates high pressure.
+    """
+    # Only check if lens indicates high urgency
+    if lens.situational_context.urgency != Urgency.HIGH:
+        return False
+
+    response_lower = response.lower()
+
+    # Check if any context keywords are present
+    has_context_reference = any(
+        keyword in response_lower for keyword in CONTEXT_KEYWORDS
+    )
+
+    # If high pressure but no context references, flag as ignored
+    return not has_context_reference
+
+
+def detect_drift(response: str, lens: Lens) -> DriftResult:
+    """
+    Detect drift/quality issues in LLM response.
+
+    Only checks the three rules from spec section 7.1:
+    A. Over-Certainty
+    B. Sycophancy-Lite
+    C. Context Ignorance (only when high pressure)
+
+    Args:
+        response: LLM response to check
+        lens: The lens used for context
+
+    Returns:
+        DriftResult indicating if drift was detected and what type
+    """
+    # Check A: Over-Certainty
+    if _check_over_certainty(response):
+        return DriftResult(
+            drift_detected=True,
+            drift_type="over_certainty",
+            modifier="Express appropriate uncertainty.",
+        )
+
+    # Check B: Sycophancy-Lite
+    if _check_sycophancy(response):
+        return DriftResult(
+            drift_detected=True,
+            drift_type="sycophancy",
+            modifier="Be objective. Do not mirror assumptions.",
+        )
+
+    # Check C: Context Ignorance
+    if _check_context_ignorance(response, lens):
+        return DriftResult(
+            drift_detected=True,
+            drift_type="ignored_context",
+            modifier="Explicitly consider the user's situation.",
+        )
+
+    return DriftResult(drift_detected=False)
+
+
+def get_regeneration_prompt_modifier(drift_result: DriftResult) -> Optional[str]:
+    """
+    Get the prompt modifier for regeneration based on drift type.
+
+    From spec section 7.2 - regeneration modifiers.
+
+    Returns:
+        Modifier string to append to system prompt, or None if no drift
+    """
+    return drift_result.modifier

--- a/app/services/lens_assembly.py
+++ b/app/services/lens_assembly.py
@@ -1,0 +1,174 @@
+from typing import Union, Optional
+import yaml
+
+from app.config import settings
+from app.models import (
+    TimeContext,
+    CalendarContextAvailable,
+    CalendarContextUnavailable,
+    RoleGuess,
+    RoleType,
+    Lens,
+    ResponsePreferences,
+    SituationalContext,
+    Tone,
+    Verbosity,
+    Hedging,
+    Urgency,
+    Pressure,
+    Interruptibility,
+)
+
+
+# Mapping rules from spec section 5.2 - DETERMINISTIC
+ROLE_TO_TONE = {
+    RoleType.PROFESSIONAL: Tone.PROFESSIONAL,
+    RoleType.PERSONAL: Tone.WARM,
+    RoleType.CASUAL: Tone.CASUAL,
+}
+
+ROLE_TO_VERBOSITY = {
+    RoleType.PROFESSIONAL: Verbosity.CONCISE,
+    RoleType.PERSONAL: Verbosity.BALANCED,
+    RoleType.CASUAL: Verbosity.CONCISE,
+}
+
+PRESSURE_TO_URGENCY = {
+    Pressure.LOW: Urgency.LOW,
+    Pressure.MODERATE: Urgency.MEDIUM,
+    Pressure.HIGH: Urgency.HIGH,
+}
+
+
+def _determine_hedging(role_confidence: float) -> Hedging:
+    """
+    Determine hedging level based on role confidence.
+    Higher confidence = less hedging needed.
+    """
+    if role_confidence >= 0.7:
+        return Hedging.LOW
+    elif role_confidence >= 0.5:
+        return Hedging.MODERATE
+    else:
+        return Hedging.HIGH
+
+
+def assemble_lens(
+    time_context: TimeContext,
+    calendar_context: Union[CalendarContextAvailable, CalendarContextUnavailable],
+    role_guess: Optional[RoleGuess],
+) -> Lens:
+    """
+    Assemble the lens from context services.
+
+    This is DETERMINISTIC - no ML, no learning.
+
+    Inclusion logic from spec section 5.3:
+    - include_calendar = calendar_confidence >= 0.3
+    - include_role = role_confidence >= 0.4
+    - Time context is always included
+
+    Args:
+        time_context: Time context (always included)
+        calendar_context: Calendar context (included if confidence >= 0.3)
+        role_guess: Role guess (included if confidence >= 0.4)
+
+    Returns:
+        Assembled Lens
+    """
+    sources_used = ["time_context"]
+
+    # Determine if calendar should be included
+    include_calendar = (
+        isinstance(calendar_context, CalendarContextAvailable)
+        and calendar_context.confidence >= settings.calendar_confidence_threshold
+    )
+
+    if include_calendar:
+        sources_used.append("calendar_context")
+
+    # Determine if role should be included
+    include_role = (
+        role_guess is not None
+        and role_guess.confidence >= settings.role_confidence_threshold
+    )
+
+    if include_role:
+        sources_used.append("role_guess")
+
+    # Determine active role
+    if include_role and role_guess:
+        active_role = role_guess.primary_role
+        role_confidence = role_guess.confidence
+    else:
+        # Default to professional during business hours, casual otherwise
+        if time_context.business_hours:
+            active_role = RoleType.PROFESSIONAL
+        else:
+            active_role = RoleType.CASUAL
+        role_confidence = 0.5  # Default confidence
+
+    # Build response preferences using mapping rules
+    response_preferences = ResponsePreferences(
+        tone=ROLE_TO_TONE[active_role],
+        verbosity=ROLE_TO_VERBOSITY[active_role],
+        hedging=_determine_hedging(role_confidence),
+    )
+
+    # Determine urgency and interruptibility
+    if include_calendar and isinstance(calendar_context, CalendarContextAvailable):
+        urgency = PRESSURE_TO_URGENCY[calendar_context.pressure]
+        interruptibility = calendar_context.interruptibility
+    else:
+        # Default based on time context
+        if time_context.urgency_bias >= 0.7:
+            urgency = Urgency.HIGH
+        elif time_context.urgency_bias >= 0.4:
+            urgency = Urgency.MEDIUM
+        else:
+            urgency = Urgency.LOW
+
+        # Default interruptibility based on business hours
+        if time_context.business_hours:
+            interruptibility = Interruptibility.MEDIUM
+        else:
+            interruptibility = Interruptibility.HIGH
+
+    situational_context = SituationalContext(
+        time_of_day=time_context.time_of_day,
+        urgency=urgency,
+        interruptibility=interruptibility,
+    )
+
+    return Lens(
+        active_role=active_role,
+        role_confidence=role_confidence,
+        response_preferences=response_preferences,
+        situational_context=situational_context,
+        sources_used=sources_used,
+    )
+
+
+def lens_to_yaml(lens: Lens) -> str:
+    """
+    Convert Lens to YAML string for injection into LLM prompt.
+    """
+    lens_dict = {
+        "lens": {
+            "active_role": lens.active_role.value,
+            "role_confidence": lens.role_confidence,
+            "response_preferences": {
+                "tone": lens.response_preferences.tone.value,
+                "verbosity": lens.response_preferences.verbosity.value,
+                "hedging": lens.response_preferences.hedging.value,
+            },
+            "situational_context": {
+                "time_of_day": lens.situational_context.time_of_day.value,
+                "urgency": lens.situational_context.urgency.value,
+                "interruptibility": lens.situational_context.interruptibility.value,
+            },
+            "sources_used": lens.sources_used,
+        }
+    }
+
+    return yaml.dump(lens_dict, default_flow_style=False, sort_keys=False)

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -1,0 +1,138 @@
+import httpx
+from typing import Optional
+
+from app.config import settings
+
+
+class LLMClient:
+    """
+    Async LLM client using httpx.
+    Supports OpenAI OR Anthropic based on configuration.
+    No SDK magic - direct HTTP calls.
+    """
+
+    def __init__(self):
+        self.provider = settings.llm_provider
+        self.timeout = httpx.Timeout(60.0, connect=10.0)
+
+    async def _call_openai(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int,
+    ) -> str:
+        """Make a call to OpenAI API."""
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(
+                "https://api.openai.com/v1/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {settings.openai_api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": settings.openai_model,
+                    "messages": [
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                    "max_tokens": max_tokens,
+                    "temperature": 0.7,
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data["choices"][0]["message"]["content"]
+
+    async def _call_anthropic(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int,
+    ) -> str:
+        """Make a call to Anthropic API."""
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(
+                "https://api.anthropic.com/v1/messages",
+                headers={
+                    "x-api-key": settings.anthropic_api_key,
+                    "anthropic-version": "2023-06-01",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": settings.anthropic_model,
+                    "max_tokens": max_tokens,
+                    "system": system_prompt,
+                    "messages": [
+                        {"role": "user", "content": user_prompt},
+                    ],
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data["content"][0]["text"]
+
+    async def call(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int,
+    ) -> str:
+        """
+        Make an LLM call using the configured provider.
+
+        Args:
+            system_prompt: System message
+            user_prompt: User message
+            max_tokens: Maximum tokens in response
+
+        Returns:
+            Response text from LLM
+
+        Raises:
+            httpx.HTTPStatusError: On API errors
+        """
+        if self.provider == "openai":
+            return await self._call_openai(system_prompt, user_prompt, max_tokens)
+        else:
+            return await self._call_anthropic(system_prompt, user_prompt, max_tokens)
+
+    async def micro_call(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+    ) -> str:
+        """
+        Make a micro LLM call (for context extraction).
+        Uses configured max tokens for micro calls (≤300 per spec).
+        """
+        return await self.call(
+            system_prompt,
+            user_prompt,
+            settings.micro_call_max_tokens,
+        )
+
+    async def primary_call(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+    ) -> str:
+        """
+        Make the primary LLM call (for main response).
+        Uses configured max tokens for primary calls.
+        """
+        return await self.call(
+            system_prompt,
+            user_prompt,
+            settings.primary_call_max_tokens,
+        )
+
+    def get_model_name(self) -> str:
+        """Return the model name being used."""
+        if self.provider == "openai":
+            return settings.openai_model
+        else:
+            return settings.anthropic_model
+
+
+# Singleton instance
+llm_client = LLMClient()

--- a/app/services/role_guess.py
+++ b/app/services/role_guess.py
@@ -1,0 +1,140 @@
+from typing import Union, Optional
+import yaml
+
+from app.models import (
+    TimeContext,
+    CalendarContextAvailable,
+    CalendarContextUnavailable,
+    RoleGuess,
+    RoleProbabilities,
+    RoleType,
+)
+from app.services.llm_client import llm_client
+
+
+# FIXED prompt from spec section 4.3 - DO NOT MODIFY
+ROLE_SYSTEM_PROMPT = """You infer which role best fits the user's current query and situation.
+Return YAML only."""
+
+ROLE_USER_PROMPT_TEMPLATE = """Query: {query}
+Time context: {time_context}
+Calendar context: {calendar_context}
+
+Return probabilities that sum to 1."""
+
+
+def _format_time_context(time_context: TimeContext) -> str:
+    """Format time context for prompt."""
+    return yaml.dump({
+        "current_iso": time_context.current_iso,
+        "time_of_day": time_context.time_of_day.value,
+        "weekday": time_context.weekday,
+        "business_hours": time_context.business_hours,
+        "urgency_bias": time_context.urgency_bias,
+    }, default_flow_style=False)
+
+
+def _format_calendar_context(
+    calendar_context: Union[CalendarContextAvailable, CalendarContextUnavailable]
+) -> str:
+    """Format calendar context for prompt."""
+    if isinstance(calendar_context, CalendarContextUnavailable):
+        return "unavailable"
+
+    return yaml.dump({
+        "summary": calendar_context.summary,
+        "pressure": calendar_context.pressure.value,
+        "interruptibility": calendar_context.interruptibility.value,
+        "role_signal": calendar_context.role_signal.value,
+        "confidence": calendar_context.confidence,
+    }, default_flow_style=False)
+
+
+def _parse_role_response(response: str) -> RoleGuess:
+    """Parse YAML response from LLM into RoleGuess."""
+    # Clean response - remove markdown code blocks if present
+    response = response.strip()
+    if response.startswith("```"):
+        lines = response.split("\n")
+        lines = [l for l in lines if not l.startswith("```")]
+        response = "\n".join(lines)
+
+    parsed = yaml.safe_load(response)
+
+    # Handle nested structure if present
+    if "role_guess" in parsed:
+        parsed = parsed["role_guess"]
+
+    roles_data = parsed.get("roles", {})
+
+    # Ensure all three roles are present (per spec)
+    professional = float(roles_data.get("professional", 0.33))
+    personal = float(roles_data.get("personal", 0.33))
+    casual = float(roles_data.get("casual", 0.34))
+
+    # Normalize to ensure sum = 1
+    total = professional + personal + casual
+    if total > 0:
+        professional /= total
+        personal /= total
+        casual /= total
+
+    roles = RoleProbabilities(
+        professional=round(professional, 2),
+        personal=round(personal, 2),
+        casual=round(casual, 2),
+    )
+
+    primary_role_str = parsed.get("primary_role", "professional")
+    primary_role = RoleType(primary_role_str)
+
+    confidence = float(parsed.get("confidence", 0.5))
+
+    return RoleGuess(
+        roles=roles,
+        primary_role=primary_role,
+        confidence=confidence,
+    )
+
+
+async def get_role_guess(
+    query: str,
+    time_context: TimeContext,
+    calendar_context: Union[CalendarContextAvailable, CalendarContextUnavailable],
+) -> Optional[RoleGuess]:
+    """
+    Get role guess using LLM micro-call.
+
+    Args:
+        query: User's query
+        time_context: Time context
+        calendar_context: Calendar context (available or unavailable)
+
+    Returns:
+        RoleGuess if successful, None on failure
+
+    Per spec:
+    - Must always return all 3 roles
+    - No memory
+    - No learning
+    """
+    try:
+        time_ctx_str = _format_time_context(time_context)
+        calendar_ctx_str = _format_calendar_context(calendar_context)
+
+        user_prompt = ROLE_USER_PROMPT_TEMPLATE.format(
+            query=query,
+            time_context=time_ctx_str,
+            calendar_context=calendar_ctx_str,
+        )
+
+        response = await llm_client.micro_call(
+            system_prompt=ROLE_SYSTEM_PROMPT,
+            user_prompt=user_prompt,
+        )
+
+        return _parse_role_response(response)
+
+    except Exception:
+        # Per spec section 9: LLM micro-call fails -> exclude that context
+        return None

--- a/app/services/time_context.py
+++ b/app/services/time_context.py
@@ -1,0 +1,96 @@
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from app.models import TimeContext, TimeOfDay
+
+
+def get_time_of_day(hour: int) -> TimeOfDay:
+    """
+    Determine time of day bucket from hour.
+
+    Rules from spec section 4.1:
+    - morning: 05-11
+    - afternoon: 11-17
+    - evening: 17-22
+    - night: 22-05
+    """
+    if 5 <= hour < 11:
+        return TimeOfDay.MORNING
+    elif 11 <= hour < 17:
+        return TimeOfDay.AFTERNOON
+    elif 17 <= hour < 22:
+        return TimeOfDay.EVENING
+    else:
+        return TimeOfDay.NIGHT
+
+
+def is_business_hours(hour: int, is_weekday: bool) -> bool:
+    """Check if current time is during business hours (9-17 on weekdays)."""
+    return is_weekday and 9 <= hour < 17
+
+
+def calculate_urgency_bias(hour: int, is_weekday: bool, is_business_hours: bool) -> float:
+    """
+    Calculate urgency bias based on time context.
+
+    Higher bias during business hours and afternoon peak.
+    Lower bias during night/early morning and weekends.
+    """
+    base_bias = 0.5
+
+    # Weekday adjustment
+    if not is_weekday:
+        base_bias -= 0.2
+
+    # Business hours adjustment
+    if is_business_hours:
+        base_bias += 0.2
+
+    # Time of day adjustment
+    time_of_day = get_time_of_day(hour)
+    if time_of_day == TimeOfDay.AFTERNOON:
+        base_bias += 0.1
+    elif time_of_day == TimeOfDay.NIGHT:
+        base_bias -= 0.2
+    elif time_of_day == TimeOfDay.MORNING:
+        base_bias += 0.05
+
+    # Clamp to 0-1
+    return max(0.0, min(1.0, base_bias))
+
+
+def get_time_context(tz_name: str = "UTC") -> TimeContext:
+    """
+    Get time context from system time.
+
+    This is a zero-cost, always-available, deterministic function.
+    No LLM usage, no I/O.
+
+    Args:
+        tz_name: Timezone name (e.g., "America/Los_Angeles", "UTC")
+
+    Returns:
+        TimeContext with current time information
+    """
+    try:
+        tz = ZoneInfo(tz_name)
+    except Exception:
+        tz = timezone.utc
+
+    now = datetime.now(tz)
+
+    hour = now.hour
+    # Monday = 0, Sunday = 6
+    is_weekday = now.weekday() < 5
+
+    time_of_day = get_time_of_day(hour)
+    business_hours = is_business_hours(hour, is_weekday)
+    urgency_bias = calculate_urgency_bias(hour, is_weekday, business_hours)
+
+    return TimeContext(
+        current_iso=now.isoformat(),
+        time_of_day=time_of_day,
+        weekday=is_weekday,
+        business_hours=business_hours,
+        urgency_bias=round(urgency_bias, 2),
+    )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+asyncio_mode = auto

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+fastapi==0.109.0
+uvicorn[standard]==0.27.0
+httpx==0.26.0
+pyyaml==6.0.1
+pydantic==2.5.3
+pydantic-settings==2.1.0
+google-auth==2.27.0
+google-auth-oauthlib==1.2.0
+google-api-python-client==2.115.0
+pytest==7.4.4
+pytest-asyncio==0.23.3
+python-dotenv==1.0.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# PersonaLens Tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_settings():
+    """Reset settings between tests."""
+    yield

--- a/tests/test_drift_guard.py
+++ b/tests/test_drift_guard.py
@@ -1,0 +1,165 @@
+import pytest
+from app.services.drift_guard import detect_drift
+from app.models import (
+    Lens,
+    ResponsePreferences,
+    SituationalContext,
+    RoleType,
+    Tone,
+    Verbosity,
+    Hedging,
+    TimeOfDay,
+    Urgency,
+    Interruptibility,
+)
+
+
+@pytest.fixture
+def high_urgency_lens():
+    return Lens(
+        active_role=RoleType.PROFESSIONAL,
+        role_confidence=0.72,
+        response_preferences=ResponsePreferences(
+            tone=Tone.PROFESSIONAL,
+            verbosity=Verbosity.CONCISE,
+            hedging=Hedging.MODERATE,
+        ),
+        situational_context=SituationalContext(
+            time_of_day=TimeOfDay.AFTERNOON,
+            urgency=Urgency.HIGH,
+            interruptibility=Interruptibility.LOW,
+        ),
+        sources_used=["time_context", "calendar_context", "role_guess"],
+    )
+
+
+@pytest.fixture
+def low_urgency_lens():
+    return Lens(
+        active_role=RoleType.CASUAL,
+        role_confidence=0.5,
+        response_preferences=ResponsePreferences(
+            tone=Tone.CASUAL,
+            verbosity=Verbosity.CONCISE,
+            hedging=Hedging.MODERATE,
+        ),
+        situational_context=SituationalContext(
+            time_of_day=TimeOfDay.EVENING,
+            urgency=Urgency.LOW,
+            interruptibility=Interruptibility.HIGH,
+        ),
+        sources_used=["time_context"],
+    )
+
+
+class TestOverCertaintyDetection:
+    """Test over-certainty detection per spec section 7.1.A."""
+
+    def test_detects_definitely(self, low_urgency_lens):
+        response = "You should definitely use this approach."
+        result = detect_drift(response, low_urgency_lens)
+        assert result.drift_detected is True
+        assert result.drift_type == "over_certainty"
+
+    def test_detects_always(self, low_urgency_lens):
+        response = "This always works in every situation."
+        result = detect_drift(response, low_urgency_lens)
+        assert result.drift_detected is True
+        assert result.drift_type == "over_certainty"
+
+    def test_detects_never(self, low_urgency_lens):
+        response = "You should never do that."
+        result = detect_drift(response, low_urgency_lens)
+        assert result.drift_detected is True
+        assert result.drift_type == "over_certainty"
+
+    def test_detects_100_percent(self, low_urgency_lens):
+        response = "This is 100% the right choice."
+        result = detect_drift(response, low_urgency_lens)
+        assert result.drift_detected is True
+        assert result.drift_type == "over_certainty"
+
+    def test_case_insensitive(self, low_urgency_lens):
+        response = "You should DEFINITELY consider this."
+        result = detect_drift(response, low_urgency_lens)
+        assert result.drift_detected is True
+
+    def test_no_false_positive_on_normal_text(self, low_urgency_lens):
+        response = "This approach might work well for your needs."
+        result = detect_drift(response, low_urgency_lens)
+        assert result.drift_detected is False
+
+
+class TestSycophancyDetection:
+    """Test sycophancy-lite detection per spec section 7.1.B."""
+
+    def test_detects_absolutely_right(self, low_urgency_lens):
+        response = "You're absolutely right about this."
+        result = detect_drift(response, low_urgency_lens)
+        assert result.drift_detected is True
+        assert result.drift_type == "sycophancy"
+
+    def test_detects_great_point(self, low_urgency_lens):
+        response = "Great point! Let me explain further."
+        result = detect_drift(response, low_urgency_lens)
+        assert result.drift_detected is True
+        assert result.drift_type == "sycophancy"
+
+    def test_detects_couldnt_agree_more(self, low_urgency_lens):
+        response = "I couldn't agree more with your assessment."
+        result = detect_drift(response, low_urgency_lens)
+        assert result.drift_detected is True
+        assert result.drift_type == "sycophancy"
+
+    def test_no_false_positive_on_agreement(self, low_urgency_lens):
+        response = "I agree that this is a valid approach."
+        result = detect_drift(response, low_urgency_lens)
+        assert result.drift_detected is False
+
+
+class TestContextIgnoranceDetection:
+    """Test context ignorance detection per spec section 7.1.C."""
+
+    def test_detects_ignored_context_high_pressure(self, high_urgency_lens):
+        """Should flag when high pressure lens but no context references."""
+        response = "Here is a comprehensive overview of all the options you might consider exploring."
+        result = detect_drift(response, high_urgency_lens)
+        assert result.drift_detected is True
+        assert result.drift_type == "ignored_context"
+
+    def test_passes_when_context_referenced(self, high_urgency_lens):
+        """Should pass when response references time pressure."""
+        response = "Given the time pressure, here's a quick summary."
+        result = detect_drift(response, high_urgency_lens)
+        assert result.drift_detected is False
+
+    def test_passes_with_urgency_reference(self, high_urgency_lens):
+        """Should pass when response references urgency."""
+        response = "Since this is urgent, I'll be concise."
+        result = detect_drift(response, high_urgency_lens)
+        assert result.drift_detected is False
+
+    def test_no_check_for_low_urgency(self, low_urgency_lens):
+        """Should not check context ignorance for low urgency."""
+        response = "Here is a comprehensive overview of all the options."
+        result = detect_drift(response, low_urgency_lens)
+        assert result.drift_detected is False
+
+
+class TestRegenerationModifiers:
+    """Test regeneration modifiers per spec section 7.2."""
+
+    def test_over_certainty_modifier(self, low_urgency_lens):
+        response = "You should definitely do this."
+        result = detect_drift(response, low_urgency_lens)
+        assert result.modifier == "Express appropriate uncertainty."
+
+    def test_sycophancy_modifier(self, low_urgency_lens):
+        response = "Great point! Here's more info."
+        result = detect_drift(response, low_urgency_lens)
+        assert result.modifier == "Be objective. Do not mirror assumptions."
+
+    def test_ignored_context_modifier(self, high_urgency_lens):
+        response = "Here's a detailed exploration of every possibility."
+        result = detect_drift(response, high_urgency_lens)
+        assert result.modifier == "Explicitly consider the user's situation."

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,303 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.models import (
+    TimeContext,
+    TimeOfDay,
+    CalendarContextAvailable,
+    CalendarContextUnavailable,
+    RoleGuess,
+    RoleProbabilities,
+    RoleType,
+    Pressure,
+    Interruptibility,
+    RoleSignal,
+)
+
+
+client = TestClient(app)
+
+
+class TestHealthCheck:
+    """Test health endpoint."""
+
+    def test_health_returns_200(self):
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json() == {"status": "healthy"}
+
+
+class TestCalendarAvailability:
+    """Test calendar available vs unavailable scenarios per spec section 10.2."""
+
+    @pytest.mark.asyncio
+    async def test_lens_preview_without_calendar(self):
+        """Should work when calendar is unavailable."""
+        with patch("app.routers.api.get_time_context") as mock_time, \
+             patch("app.routers.api.get_calendar_context") as mock_cal, \
+             patch("app.routers.api.get_role_guess") as mock_role:
+
+            mock_time.return_value = TimeContext(
+                current_iso="2025-12-15T14:30:00-08:00",
+                time_of_day=TimeOfDay.AFTERNOON,
+                weekday=True,
+                business_hours=True,
+                urgency_bias=0.7,
+            )
+
+            mock_cal.return_value = CalendarContextUnavailable()
+
+            mock_role.return_value = RoleGuess(
+                roles=RoleProbabilities(
+                    professional=0.6,
+                    personal=0.3,
+                    casual=0.1,
+                ),
+                primary_role=RoleType.PROFESSIONAL,
+                confidence=0.6,
+            )
+
+            response = client.post(
+                "/lens/preview",
+                json={"query": "How should I prepare for my meeting?"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert "calendar_context" not in data["sources_used"]
+            assert "time_context" in data["sources_used"]
+
+    @pytest.mark.asyncio
+    async def test_lens_preview_with_calendar(self):
+        """Should include calendar when available and above threshold."""
+        with patch("app.routers.api.get_time_context") as mock_time, \
+             patch("app.routers.api.get_calendar_context") as mock_cal, \
+             patch("app.routers.api.get_role_guess") as mock_role:
+
+            mock_time.return_value = TimeContext(
+                current_iso="2025-12-15T14:30:00-08:00",
+                time_of_day=TimeOfDay.AFTERNOON,
+                weekday=True,
+                business_hours=True,
+                urgency_bias=0.7,
+            )
+
+            mock_cal.return_value = CalendarContextAvailable(
+                summary="Client meeting in 45 minutes",
+                pressure=Pressure.HIGH,
+                interruptibility=Interruptibility.LOW,
+                role_signal=RoleSignal.PROFESSIONAL,
+                confidence=0.88,
+            )
+
+            mock_role.return_value = RoleGuess(
+                roles=RoleProbabilities(
+                    professional=0.72,
+                    personal=0.21,
+                    casual=0.07,
+                ),
+                primary_role=RoleType.PROFESSIONAL,
+                confidence=0.72,
+            )
+
+            response = client.post(
+                "/lens/preview",
+                json={"query": "How should I prepare for my meeting?"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert "calendar_context" in data["sources_used"]
+
+
+class TestPressureScenarios:
+    """Test high pressure vs low pressure scenarios per spec section 10.2."""
+
+    @pytest.mark.asyncio
+    async def test_high_pressure_lens(self):
+        """High pressure calendar should result in high urgency lens."""
+        with patch("app.routers.api.get_time_context") as mock_time, \
+             patch("app.routers.api.get_calendar_context") as mock_cal, \
+             patch("app.routers.api.get_role_guess") as mock_role:
+
+            mock_time.return_value = TimeContext(
+                current_iso="2025-12-15T14:30:00-08:00",
+                time_of_day=TimeOfDay.AFTERNOON,
+                weekday=True,
+                business_hours=True,
+                urgency_bias=0.7,
+            )
+
+            mock_cal.return_value = CalendarContextAvailable(
+                summary="Client meeting in 15 minutes",
+                pressure=Pressure.HIGH,
+                interruptibility=Interruptibility.LOW,
+                role_signal=RoleSignal.PROFESSIONAL,
+                confidence=0.9,
+            )
+
+            mock_role.return_value = RoleGuess(
+                roles=RoleProbabilities(
+                    professional=0.8,
+                    personal=0.15,
+                    casual=0.05,
+                ),
+                primary_role=RoleType.PROFESSIONAL,
+                confidence=0.8,
+            )
+
+            response = client.post(
+                "/lens/preview",
+                json={"query": "Quick summary of best practices?"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["lens"]["situational_context"]["urgency"] == "high"
+            assert data["lens"]["situational_context"]["interruptibility"] == "low"
+
+    @pytest.mark.asyncio
+    async def test_low_pressure_lens(self):
+        """Low pressure calendar should result in low urgency lens."""
+        with patch("app.routers.api.get_time_context") as mock_time, \
+             patch("app.routers.api.get_calendar_context") as mock_cal, \
+             patch("app.routers.api.get_role_guess") as mock_role:
+
+            mock_time.return_value = TimeContext(
+                current_iso="2025-12-15T20:30:00-08:00",
+                time_of_day=TimeOfDay.EVENING,
+                weekday=False,
+                business_hours=False,
+                urgency_bias=0.3,
+            )
+
+            mock_cal.return_value = CalendarContextAvailable(
+                summary="Casual dinner with friends tomorrow",
+                pressure=Pressure.LOW,
+                interruptibility=Interruptibility.HIGH,
+                role_signal=RoleSignal.PERSONAL,
+                confidence=0.7,
+            )
+
+            mock_role.return_value = RoleGuess(
+                roles=RoleProbabilities(
+                    professional=0.1,
+                    personal=0.6,
+                    casual=0.3,
+                ),
+                primary_role=RoleType.PERSONAL,
+                confidence=0.6,
+            )
+
+            response = client.post(
+                "/lens/preview",
+                json={"query": "What should I bring to a dinner party?"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["lens"]["situational_context"]["urgency"] == "low"
+
+
+class TestRegenerationTriggers:
+    """Test regeneration scenarios per spec sections 7 and 10.2."""
+
+    @pytest.mark.asyncio
+    async def test_over_certainty_triggers_regeneration(self):
+        """Over-certainty in response should trigger regeneration."""
+        with patch("app.routers.api.get_time_context") as mock_time, \
+             patch("app.routers.api.get_calendar_context") as mock_cal, \
+             patch("app.routers.api.get_role_guess") as mock_role, \
+             patch("app.routers.api.llm_client") as mock_llm:
+
+            mock_time.return_value = TimeContext(
+                current_iso="2025-12-15T14:30:00-08:00",
+                time_of_day=TimeOfDay.AFTERNOON,
+                weekday=True,
+                business_hours=True,
+                urgency_bias=0.7,
+            )
+
+            mock_cal.return_value = CalendarContextUnavailable()
+
+            mock_role.return_value = RoleGuess(
+                roles=RoleProbabilities(
+                    professional=0.6,
+                    personal=0.3,
+                    casual=0.1,
+                ),
+                primary_role=RoleType.PROFESSIONAL,
+                confidence=0.6,
+            )
+
+            # First response has over-certainty, second is clean
+            mock_llm.primary_call = AsyncMock(
+                side_effect=[
+                    "You should definitely use this approach.",
+                    "This approach is generally recommended.",
+                ]
+            )
+            mock_llm.get_model_name.return_value = "claude-3-5-sonnet"
+
+            response = client.post(
+                "/query",
+                json={"query": "What approach should I use?"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["regenerated"] is True
+            assert "definitely" not in data["response"].lower()
+
+    @pytest.mark.asyncio
+    async def test_max_one_regeneration(self):
+        """Should only regenerate maximum once per spec."""
+        with patch("app.routers.api.get_time_context") as mock_time, \
+             patch("app.routers.api.get_calendar_context") as mock_cal, \
+             patch("app.routers.api.get_role_guess") as mock_role, \
+             patch("app.routers.api.llm_client") as mock_llm:
+
+            mock_time.return_value = TimeContext(
+                current_iso="2025-12-15T14:30:00-08:00",
+                time_of_day=TimeOfDay.AFTERNOON,
+                weekday=True,
+                business_hours=True,
+                urgency_bias=0.7,
+            )
+
+            mock_cal.return_value = CalendarContextUnavailable()
+
+            mock_role.return_value = RoleGuess(
+                roles=RoleProbabilities(
+                    professional=0.6,
+                    personal=0.3,
+                    casual=0.1,
+                ),
+                primary_role=RoleType.PROFESSIONAL,
+                confidence=0.6,
+            )
+
+            # Both responses have drift
+            mock_llm.primary_call = AsyncMock(
+                side_effect=[
+                    "You should definitely do this.",
+                    "You're absolutely right, definitely do it.",
+                ]
+            )
+            mock_llm.get_model_name.return_value = "claude-3-5-sonnet"
+
+            response = client.post(
+                "/query",
+                json={"query": "What should I do?"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["regenerated"] is True
+            # Should have warning since second attempt also failed
+            assert data["warning"] is not None
+            # Should only have called primary_call twice (original + 1 regeneration)
+            assert mock_llm.primary_call.call_count == 2

--- a/tests/test_lens_assembly.py
+++ b/tests/test_lens_assembly.py
@@ -1,0 +1,214 @@
+import pytest
+from app.services.lens_assembly import assemble_lens, lens_to_yaml
+from app.models import (
+    TimeContext,
+    TimeOfDay,
+    CalendarContextAvailable,
+    CalendarContextUnavailable,
+    RoleGuess,
+    RoleProbabilities,
+    RoleType,
+    Pressure,
+    Interruptibility,
+    RoleSignal,
+    Tone,
+    Verbosity,
+    Urgency,
+)
+
+
+@pytest.fixture
+def sample_time_context():
+    return TimeContext(
+        current_iso="2025-12-15T14:30:00-08:00",
+        time_of_day=TimeOfDay.AFTERNOON,
+        weekday=True,
+        business_hours=True,
+        urgency_bias=0.7,
+    )
+
+
+@pytest.fixture
+def high_pressure_calendar():
+    return CalendarContextAvailable(
+        summary="Client meeting in 45 minutes",
+        pressure=Pressure.HIGH,
+        interruptibility=Interruptibility.LOW,
+        role_signal=RoleSignal.PROFESSIONAL,
+        confidence=0.88,
+    )
+
+
+@pytest.fixture
+def low_confidence_calendar():
+    return CalendarContextAvailable(
+        summary="Maybe something later",
+        pressure=Pressure.LOW,
+        interruptibility=Interruptibility.HIGH,
+        role_signal=RoleSignal.MIXED,
+        confidence=0.2,  # Below threshold
+    )
+
+
+@pytest.fixture
+def professional_role_guess():
+    return RoleGuess(
+        roles=RoleProbabilities(
+            professional=0.72,
+            personal=0.21,
+            casual=0.07,
+        ),
+        primary_role=RoleType.PROFESSIONAL,
+        confidence=0.72,
+    )
+
+
+@pytest.fixture
+def low_confidence_role_guess():
+    return RoleGuess(
+        roles=RoleProbabilities(
+            professional=0.35,
+            personal=0.33,
+            casual=0.32,
+        ),
+        primary_role=RoleType.PROFESSIONAL,
+        confidence=0.35,  # Below threshold
+    )
+
+
+class TestLensAssembly:
+    """Test deterministic lens assembly per spec section 5."""
+
+    def test_lens_schema_validation(
+        self, sample_time_context, high_pressure_calendar, professional_role_guess
+    ):
+        """Lens should match schema from spec section 5.1."""
+        lens = assemble_lens(
+            time_context=sample_time_context,
+            calendar_context=high_pressure_calendar,
+            role_guess=professional_role_guess,
+        )
+
+        # Check required fields exist
+        assert lens.active_role is not None
+        assert lens.role_confidence is not None
+        assert lens.response_preferences is not None
+        assert lens.situational_context is not None
+        assert lens.sources_used is not None
+
+        # Check nested structures
+        assert lens.response_preferences.tone is not None
+        assert lens.response_preferences.verbosity is not None
+        assert lens.response_preferences.hedging is not None
+
+        assert lens.situational_context.time_of_day is not None
+        assert lens.situational_context.urgency is not None
+        assert lens.situational_context.interruptibility is not None
+
+    def test_professional_role_mapping(
+        self, sample_time_context, high_pressure_calendar, professional_role_guess
+    ):
+        """Professional role should map to professional tone, concise verbosity."""
+        lens = assemble_lens(
+            time_context=sample_time_context,
+            calendar_context=high_pressure_calendar,
+            role_guess=professional_role_guess,
+        )
+
+        assert lens.active_role == RoleType.PROFESSIONAL
+        assert lens.response_preferences.tone == Tone.PROFESSIONAL
+        assert lens.response_preferences.verbosity == Verbosity.CONCISE
+
+    def test_high_pressure_urgency(
+        self, sample_time_context, high_pressure_calendar, professional_role_guess
+    ):
+        """High pressure calendar should result in high urgency."""
+        lens = assemble_lens(
+            time_context=sample_time_context,
+            calendar_context=high_pressure_calendar,
+            role_guess=professional_role_guess,
+        )
+
+        assert lens.situational_context.urgency == Urgency.HIGH
+        assert lens.situational_context.interruptibility == Interruptibility.LOW
+
+    def test_calendar_below_threshold_excluded(
+        self, sample_time_context, low_confidence_calendar, professional_role_guess
+    ):
+        """Calendar with confidence < 0.3 should be excluded."""
+        lens = assemble_lens(
+            time_context=sample_time_context,
+            calendar_context=low_confidence_calendar,
+            role_guess=professional_role_guess,
+        )
+
+        assert "calendar_context" not in lens.sources_used
+
+    def test_role_below_threshold_excluded(
+        self, sample_time_context, high_pressure_calendar, low_confidence_role_guess
+    ):
+        """Role with confidence < 0.4 should be excluded."""
+        lens = assemble_lens(
+            time_context=sample_time_context,
+            calendar_context=high_pressure_calendar,
+            role_guess=low_confidence_role_guess,
+        )
+
+        assert "role_guess" not in lens.sources_used
+
+    def test_time_context_always_included(self, sample_time_context):
+        """Time context should always be included."""
+        lens = assemble_lens(
+            time_context=sample_time_context,
+            calendar_context=CalendarContextUnavailable(),
+            role_guess=None,
+        )
+
+        assert "time_context" in lens.sources_used
+
+    def test_calendar_unavailable_continues(self, sample_time_context, professional_role_guess):
+        """Should continue when calendar is unavailable."""
+        lens = assemble_lens(
+            time_context=sample_time_context,
+            calendar_context=CalendarContextUnavailable(),
+            role_guess=professional_role_guess,
+        )
+
+        assert lens is not None
+        assert "calendar_context" not in lens.sources_used
+
+    def test_sources_tracking(
+        self, sample_time_context, high_pressure_calendar, professional_role_guess
+    ):
+        """Sources used should be accurately tracked."""
+        lens = assemble_lens(
+            time_context=sample_time_context,
+            calendar_context=high_pressure_calendar,
+            role_guess=professional_role_guess,
+        )
+
+        assert "time_context" in lens.sources_used
+        assert "calendar_context" in lens.sources_used
+        assert "role_guess" in lens.sources_used
+
+
+class TestLensToYaml:
+    """Test YAML conversion."""
+
+    def test_produces_valid_yaml(
+        self, sample_time_context, high_pressure_calendar, professional_role_guess
+    ):
+        """Should produce valid YAML string."""
+        lens = assemble_lens(
+            time_context=sample_time_context,
+            calendar_context=high_pressure_calendar,
+            role_guess=professional_role_guess,
+        )
+
+        yaml_str = lens_to_yaml(lens)
+
+        assert isinstance(yaml_str, str)
+        assert "lens:" in yaml_str
+        assert "active_role:" in yaml_str
+        assert "response_preferences:" in yaml_str
+        assert "situational_context:" in yaml_str

--- a/tests/test_role_guess.py
+++ b/tests/test_role_guess.py
@@ -1,0 +1,104 @@
+import pytest
+from app.services.role_guess import _parse_role_response
+from app.models import RoleType
+
+
+class TestRoleProbabilitySum:
+    """Test that role probabilities sum to 1 per spec section 4.3."""
+
+    def test_probabilities_sum_to_one_exact(self):
+        """Exact probabilities should sum to 1."""
+        response = """
+role_guess:
+  roles:
+    professional: 0.72
+    personal: 0.21
+    casual: 0.07
+  primary_role: professional
+  confidence: 0.72
+"""
+        role_guess = _parse_role_response(response)
+        total = (
+            role_guess.roles.professional +
+            role_guess.roles.personal +
+            role_guess.roles.casual
+        )
+        assert abs(total - 1.0) < 0.01  # Allow small rounding error
+
+    def test_probabilities_normalized(self):
+        """Non-normalized probabilities should be normalized to sum to 1."""
+        response = """
+roles:
+  professional: 0.5
+  personal: 0.3
+  casual: 0.3
+primary_role: professional
+confidence: 0.5
+"""
+        role_guess = _parse_role_response(response)
+        total = (
+            role_guess.roles.professional +
+            role_guess.roles.personal +
+            role_guess.roles.casual
+        )
+        assert abs(total - 1.0) < 0.01
+
+    def test_all_three_roles_present(self):
+        """All three roles must be present in response."""
+        response = """
+roles:
+  professional: 0.7
+  personal: 0.2
+  casual: 0.1
+primary_role: professional
+confidence: 0.7
+"""
+        role_guess = _parse_role_response(response)
+
+        assert role_guess.roles.professional is not None
+        assert role_guess.roles.personal is not None
+        assert role_guess.roles.casual is not None
+
+    def test_handles_missing_roles_gracefully(self):
+        """Missing roles should get default values."""
+        response = """
+roles:
+  professional: 1.0
+primary_role: professional
+confidence: 0.5
+"""
+        role_guess = _parse_role_response(response)
+        # Should still work with defaults
+        assert role_guess is not None
+        total = (
+            role_guess.roles.professional +
+            role_guess.roles.personal +
+            role_guess.roles.casual
+        )
+        assert abs(total - 1.0) < 0.01
+
+    def test_handles_code_block_wrapper(self):
+        """Should handle markdown code blocks in response."""
+        response = """```yaml
+roles:
+  professional: 0.6
+  personal: 0.3
+  casual: 0.1
+primary_role: professional
+confidence: 0.6
+```"""
+        role_guess = _parse_role_response(response)
+        assert role_guess.primary_role == RoleType.PROFESSIONAL
+
+    def test_confidence_in_range(self):
+        """Confidence should be between 0 and 1."""
+        response = """
+roles:
+  professional: 0.6
+  personal: 0.3
+  casual: 0.1
+primary_role: professional
+confidence: 0.6
+"""
+        role_guess = _parse_role_response(response)
+        assert 0.0 <= role_guess.confidence <= 1.0

--- a/tests/test_time_context.py
+++ b/tests/test_time_context.py
@@ -1,0 +1,98 @@
+import pytest
+from app.services.time_context import (
+    get_time_of_day,
+    is_business_hours,
+    calculate_urgency_bias,
+    get_time_context,
+)
+from app.models import TimeOfDay
+
+
+class TestGetTimeOfDay:
+    """Test time bucket correctness per spec section 4.1."""
+
+    def test_morning_5am(self):
+        assert get_time_of_day(5) == TimeOfDay.MORNING
+
+    def test_morning_10am(self):
+        assert get_time_of_day(10) == TimeOfDay.MORNING
+
+    def test_afternoon_11am(self):
+        assert get_time_of_day(11) == TimeOfDay.AFTERNOON
+
+    def test_afternoon_4pm(self):
+        assert get_time_of_day(16) == TimeOfDay.AFTERNOON
+
+    def test_evening_5pm(self):
+        assert get_time_of_day(17) == TimeOfDay.EVENING
+
+    def test_evening_9pm(self):
+        assert get_time_of_day(21) == TimeOfDay.EVENING
+
+    def test_night_10pm(self):
+        assert get_time_of_day(22) == TimeOfDay.NIGHT
+
+    def test_night_midnight(self):
+        assert get_time_of_day(0) == TimeOfDay.NIGHT
+
+    def test_night_4am(self):
+        assert get_time_of_day(4) == TimeOfDay.NIGHT
+
+
+class TestIsBusinessHours:
+    """Test business hours detection."""
+
+    def test_weekday_9am(self):
+        assert is_business_hours(9, is_weekday=True) is True
+
+    def test_weekday_4pm(self):
+        assert is_business_hours(16, is_weekday=True) is True
+
+    def test_weekday_5pm(self):
+        assert is_business_hours(17, is_weekday=True) is False
+
+    def test_weekday_8am(self):
+        assert is_business_hours(8, is_weekday=True) is False
+
+    def test_weekend_noon(self):
+        assert is_business_hours(12, is_weekday=False) is False
+
+
+class TestUrgencyBias:
+    """Test urgency bias calculation."""
+
+    def test_urgency_in_range(self):
+        """Urgency bias should always be between 0 and 1."""
+        for hour in range(24):
+            for is_weekday in [True, False]:
+                for is_bh in [True, False]:
+                    bias = calculate_urgency_bias(hour, is_weekday, is_bh)
+                    assert 0.0 <= bias <= 1.0
+
+    def test_business_hours_higher_urgency(self):
+        """Business hours should have higher urgency than non-business hours."""
+        bh_urgency = calculate_urgency_bias(12, is_weekday=True, is_business_hours=True)
+        non_bh_urgency = calculate_urgency_bias(12, is_weekday=True, is_business_hours=False)
+        assert bh_urgency > non_bh_urgency
+
+
+class TestGetTimeContext:
+    """Test full time context generation."""
+
+    def test_returns_valid_time_context(self):
+        context = get_time_context()
+
+        assert context.current_iso is not None
+        assert context.time_of_day in TimeOfDay
+        assert isinstance(context.weekday, bool)
+        assert isinstance(context.business_hours, bool)
+        assert 0.0 <= context.urgency_bias <= 1.0
+
+    def test_with_timezone(self):
+        context = get_time_context("America/Los_Angeles")
+        assert context.current_iso is not None
+
+    def test_with_invalid_timezone_falls_back(self):
+        """Invalid timezone should fall back to UTC."""
+        context = get_time_context("Invalid/Timezone")
+        assert context.current_iso is not None


### PR DESCRIPTION
This implements the complete PersonaLens MVP as specified:

Core Services:
- Time Context Service: Deterministic time bucketing (morning/afternoon/evening/night)
- Calendar Context Service: LLM micro-call to extract pressure/interruptibility
- Role Guess Service: LLM micro-call to infer user role probabilities
- Lens Assembly: Deterministic mapping from context to response preferences

API Endpoints:
- POST /query: Main query endpoint with lens injection and drift guard
- POST /lens/preview: Transparency endpoint to preview assembled lens
- GET /health: Health check

Quality Controls:
- Drift Guard: Detects over-certainty, sycophancy, and context ignorance
- Max 1 regeneration with specific prompt modifiers
- Warning flag if second attempt fails

Tech Stack (per spec):
- Python 3.11+ with FastAPI
- Async HTTP calls via httpx (no SDK magic)
- PyYAML for schema handling
- Google Calendar OAuth integration
- Single container Docker deployment

Tests:
- Unit tests for time buckets, role probability normalization, lens schema
- Integration tests for calendar availability, pressure scenarios, regeneration

Explicit Exclusions (not implemented per spec):
- No persistent memory
- No historical learning
- No embedding databases
- No background jobs